### PR TITLE
Technology

### DIFF
--- a/examples/example_inputfile.py
+++ b/examples/example_inputfile.py
@@ -8,6 +8,10 @@ genesys --infile test_inputfile.py
 """
 # So the database can be saved in the location from which
 # the command is called.
+from pygenesys.technology.supply import imp_natgas
+from pygenesys.commodity.resource import electricity, steam, ethos
+from pygenesys.data.library import campus_elc_demand, campus_stm_demand
+from pygenesys.commodity.demand import ELC_DEMAND, STM_DEMAND
 import os
 curr_dir = os.path.dirname(__file__)
 
@@ -20,29 +24,27 @@ N_seasons = 4  # the number of seasons in the model
 N_hours = 24  # the number of hours in a day
 
 # Import commodities here
-from pygenesys.commodity.demand import ELC_DEMAND, STM_DEMAND
 ELC_DEMAND.add_demand(region='IL',
                       init_demand=183,
                       start_year=start_year,
-                      end_year = end_year,
-                      N_years = N_years,
+                      end_year=end_year,
+                      N_years=N_years,
                       growth_rate=0.01)
 ELC_DEMAND.add_demand(region='UIUC',
                       init_demand=4.44,
                       start_year=start_year,
-                      end_year = end_year,
-                      N_years = N_years,
+                      end_year=end_year,
+                      N_years=N_years,
                       growth_rate=0.01)
 STM_DEMAND.add_demand(region='UIUC',
                       init_demand=6,
-                      start_year = start_year,
-                      end_year = end_year,
-                      N_years = N_years,
+                      start_year=start_year,
+                      end_year=end_year,
+                      N_years=N_years,
                       growth_rate=-0.01,
                       growth_method='exponential')
 
 # Import distribution data
-from pygenesys.data.library import campus_elc_demand, campus_stm_demand
 ELC_DEMAND.set_distribution(region='UIUC',
                             data=campus_elc_demand,
                             n_seasons=N_seasons,
@@ -54,18 +56,13 @@ STM_DEMAND.set_distribution(region='UIUC',
                             n_hours=N_hours)
 
 
-from pygenesys.commodity.resource import electricity, steam, ethos
-
 # Add technologies
-from pygenesys.technology.supply import imp_natgas
 
 
 # Collect the commodities here
 demands_list = [ELC_DEMAND, STM_DEMAND]
 resources_list = [electricity, steam, ethos]
 emissions_list = []
-
-
 
 
 if __name__ == '__main__':

--- a/examples/example_inputfile.py
+++ b/examples/example_inputfile.py
@@ -16,7 +16,7 @@ scenario_name = 'test'
 start_year = 2025
 end_year = 2050
 N_years = 6
-N_seasons = 365  # the number of seasons in the model
+N_seasons = 4  # the number of seasons in the model
 N_hours = 24  # the number of hours in a day
 
 # Import commodities here
@@ -38,7 +38,7 @@ STM_DEMAND.add_demand(region='UIUC',
                       start_year = start_year,
                       end_year = end_year,
                       N_years = N_years,
-                      growth_rate=0.01,
+                      growth_rate=-0.01,
                       growth_method='exponential')
 
 # Import distribution data
@@ -53,9 +53,15 @@ STM_DEMAND.set_distribution(region='UIUC',
                             n_seasons=N_seasons,
                             n_hours=N_hours)
 
-from pygenesys.commodity.resource import electricity, steam
+from pygenesys.commodity.resource import electricity, steam, ethos
 
 # Collect the commodities here
 demands_list = [ELC_DEMAND, STM_DEMAND]
-resources_list = [electricity, steam]
+resources_list = [electricity, steam, ethos]
 emissions_list = []
+
+if __name__ == '__main__':
+    import matplotlib.pyplot as plt
+
+    plt.plot(STM_DEMAND.demand['UIUC'])
+    plt.show()

--- a/examples/example_inputfile.py
+++ b/examples/example_inputfile.py
@@ -53,15 +53,27 @@ STM_DEMAND.set_distribution(region='UIUC',
                             n_seasons=N_seasons,
                             n_hours=N_hours)
 
+
 from pygenesys.commodity.resource import electricity, steam, ethos
+
+# Add technologies
+from pygenesys.technology.supply import imp_natgas
+
 
 # Collect the commodities here
 demands_list = [ELC_DEMAND, STM_DEMAND]
 resources_list = [electricity, steam, ethos]
 emissions_list = []
 
+
+
+
 if __name__ == '__main__':
     import matplotlib.pyplot as plt
 
-    plt.plot(STM_DEMAND.demand['UIUC'])
-    plt.show()
+    # plt.plot(STM_DEMAND.demand['UIUC'])
+    # plt.show()
+
+    print(STM_DEMAND.comm_name)
+    STM_DEMAND.comm_name = 'McSteamy'
+    print(STM_DEMAND.comm_name)

--- a/examples/example_inputfile.py
+++ b/examples/example_inputfile.py
@@ -3,7 +3,7 @@ PyGenesys Input File
 To run execute:
 
 ```bash
-genesys --infile test_inputfile.py
+genesys --infile example_inputfile.py
 ```
 """
 # So the database can be saved in the location from which

--- a/pygenesys/commodity/commodity.py
+++ b/pygenesys/commodity/commodity.py
@@ -8,7 +8,7 @@ from pygenesys.utils.tsprocess import choose_distribution_method
 #==============================================================================
 class Commodity(object):
     """
-    A ''commodity'' is a "raw material" or an "energy carrier.
+    A ''commodity'' is a "raw material" or an "energy carrier."
     This class contains information about a commodity used in a
     Temoa model.
     """

--- a/pygenesys/commodity/resource.py
+++ b/pygenesys/commodity/resource.py
@@ -5,11 +5,11 @@ electricity = Commodity(comm_name='ELC',
                         description='Electricity')
 
 steam = Commodity(comm_name='STM',
-                  units = 'GWh(th)',
-                  description = 'Steam')
+                  units='GWh(th)',
+                  description='Steam')
 
 natural_gas = Commodity(comm_name='NATGAS',
-                        units = 'MMBTU',
+                        units='MMBTU',
                         description='natural gas')
 
 ethos = Commodity(comm_name='ethos',

--- a/pygenesys/commodity/resource.py
+++ b/pygenesys/commodity/resource.py
@@ -8,6 +8,10 @@ steam = Commodity(comm_name='STM',
                   units = 'GWh(th)',
                   description = 'Steam')
 
+natural_gas = Commodity(comm_name='NATGAS',
+                        units = 'MMBTU',
+                        description='natural gas')
+
 ethos = Commodity(comm_name='ethos',
                   units='NULL',
-                  description='placeholder commodity -- infinite reservoir')                
+                  description='placeholder commodity -- infinite reservoir')

--- a/pygenesys/commodity/resource.py
+++ b/pygenesys/commodity/resource.py
@@ -7,3 +7,7 @@ electricity = Commodity(comm_name='ELC',
 steam = Commodity(comm_name='STM',
                   units = 'GWh(th)',
                   description = 'Steam')
+
+ethos = Commodity(comm_name='ethos',
+                  units='NULL',
+                  description='placeholder commodity -- infinite reservoir')                

--- a/pygenesys/driver.py
+++ b/pygenesys/driver.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import importlib
+import inspect
 import argparse
 import os
 import sys
@@ -9,6 +10,7 @@ import sqlite3
 
 # custom imports
 from pygenesys import model_info
+from pygenesys.technology.technology import Technology
 
 
 def name_from_path(infile_path):
@@ -53,6 +55,29 @@ def load_infile(infile_path):
     return infile
 
 
+def collect_technologies(module_name):
+    """
+    Collects the technologies from the PyGenesys input file.
+
+    Parameters
+    ----------
+    module_name : python module
+        The PyGenesys input file once imported. Should be "infile."
+    """
+    technologies = []
+
+    for member, attrib in inspect.getmembers(module_name):
+        try:
+            string_attr = str(attrib)
+        except:
+            string_attr = ''
+
+        if 'Technology' in string_attr:
+            print(f"{member} is Technology")
+            technologies.append(getattr(module_name, member))
+
+    return technologies
+
 def main():
 
     # Read commandline arguments
@@ -68,6 +93,9 @@ def main():
     except BaseException:
         out_path = "./" + out_db
 
+    # get infile technologies
+    technology_list = collect_technologies(infile)
+
     # create the model object
     model = model_info.ModelInfo(output_db=out_path,
                                  scenario_name=infile.scenario_name,
@@ -79,8 +107,13 @@ def main():
                                  demands = infile.demands_list,
                                  resources = infile.resources_list,
                                  emissions = infile.emissions_list,
+                                 technologies = technology_list
                                  )
     print(f"Database will be exported to {model.output_db} \n")
+
+    # print('=========================\n')
+    # print(f"{technology_list}")
+    # print('=========================\n')
 
     print(f"The years simulated by the model are \n {model.time_horizon} \n")
 

--- a/pygenesys/driver.py
+++ b/pygenesys/driver.py
@@ -69,7 +69,7 @@ def collect_technologies(module_name):
     for member, attrib in inspect.getmembers(module_name):
         try:
             string_attr = str(attrib)
-        except:
+        except BaseException:
             string_attr = ''
 
         if 'Technology' in string_attr:
@@ -77,6 +77,7 @@ def collect_technologies(module_name):
             technologies.append(getattr(module_name, member))
 
     return technologies
+
 
 def main():
 
@@ -104,10 +105,10 @@ def main():
                                  N_years=infile.N_years,
                                  N_seasons=infile.N_seasons,
                                  N_hours=infile.N_hours,
-                                 demands = infile.demands_list,
-                                 resources = infile.resources_list,
-                                 emissions = infile.emissions_list,
-                                 technologies = technology_list
+                                 demands=infile.demands_list,
+                                 resources=infile.resources_list,
+                                 emissions=infile.emissions_list,
+                                 technologies=technology_list
                                  )
     print(f"Database will be exported to {model.output_db} \n")
 

--- a/pygenesys/model_info.py
+++ b/pygenesys/model_info.py
@@ -65,10 +65,10 @@ class ModelInfo(object):
         self.N_seasons = N_seasons
         self.N_hours = N_hours
         self.commodities = {
-                            'demand':demands,
-                            'resources':resources,
-                            'emissions':emissions
-                            }
+            'demand': demands,
+            'resources': resources,
+            'emissions': emissions
+        }
         self.technologies = technologies
 
         # derived quantities
@@ -114,13 +114,11 @@ class ModelInfo(object):
 
         return np.unique(regions)
 
-
     def _collect_tech_sectors(self):
 
         sectors = np.unique([t.tech_sector for t in self.technologies])
 
         return sectors
-
 
     def _write_sqlite_database(self):
         """

--- a/pygenesys/model_info.py
+++ b/pygenesys/model_info.py
@@ -17,6 +17,7 @@ class ModelInfo(object):
                  N_years,
                  N_seasons,
                  N_hours,
+                 technologies,
                  demands,
                  resources,
                  emissions,):
@@ -51,6 +52,9 @@ class ModelInfo(object):
                 * 2; diurnal variation, step function (not implemented)
                 * 24; full day, hourly resolution
         commodities : dictionary
+            A dictionary of the demand, resource, and emissions commodities.
+        technologies : list
+             A list of ``Technology`` objects
         """
 
         self.output_db = output_db
@@ -65,13 +69,13 @@ class ModelInfo(object):
                             'resources':resources,
                             'emissions':emissions
                             }
-
+        self.technologies = technologies
 
         # derived quantities
         self.time_horizon = self._calculate_time_horizon()
         self.seg_frac = self._calculate_seg_frac()
         self.regions = self._collect_regions()
-        print(self.regions)
+        self.tech_sectors = self._collect_tech_sectors()
 
         return
 
@@ -114,6 +118,13 @@ class ModelInfo(object):
         return np.unique(regions)
 
 
+    def _collect_tech_sectors(self):
+
+        sectors = np.unique([t.tech_sector for t in self.technologies])
+
+        return sectors
+
+
     def _write_sqlite_database(self):
         """
         Writes model info directly to an sqlite database.
@@ -137,5 +148,8 @@ class ModelInfo(object):
                                             self.commodities['demand'],
                                             time_slices,
                                             seasons)
+        create_technology_labels(conn)
+        create_sectors(conn, self.tech_sectors)
+        create_technologies(conn, self.technologies)
         conn.close()
         return

--- a/pygenesys/technology.py
+++ b/pygenesys/technology.py
@@ -1,8 +1,0 @@
-def placeholder():
-    """
-    This function does nothing except
-    prints the Zen of Python.
-    """
-    import this
-
-    return

--- a/pygenesys/technology/supply.py
+++ b/pygenesys/technology/supply.py
@@ -11,7 +11,7 @@ imp_natgas = Technology(tech_name='IMP_NATGAS',
                         input_comm=ethos,
                         output_comm=natural_gas,
                         units="MMBTU/hr",
-                        tech_sector = 'supply',
+                        tech_sector='supply',
                         tech_lifetime=1000,
                         loan_lifetime=None,
                         )

--- a/pygenesys/technology/supply.py
+++ b/pygenesys/technology/supply.py
@@ -1,0 +1,22 @@
+"""
+This file contains information for pre-made import technologies. These
+technologies serve to "create" basic energy carriers, like natural gas or
+gasoline.
+"""
+
+from pygenesys.technology.technology import Technology
+from pygenesys.commodity.resource import ethos, natural_gas
+
+imp_natgas = Technology(tech_name='IMP_NATGAS',
+                        input_comm=ethos,
+                        output_comm=natural_gas,
+                        units="MMBTU/hr",
+                        tech_sector = 'supply',
+                        tech_lifetime=1000,
+                        loan_lifetime=None,
+                        )
+
+
+if __name__ == '__main__':
+    print(isinstance(imp_natgas, Technology))
+    print(imp_natgas._type)

--- a/pygenesys/technology/technology.py
+++ b/pygenesys/technology/technology.py
@@ -1,0 +1,39 @@
+
+#==============================================================================
+#==============================================================================
+# Defines Technology
+#==============================================================================
+#==============================================================================
+class Technology(object):
+    """
+    This class holds the information for technologies
+    in a Temoa simulation. A ``Technology`` transforms
+    one energy carrier into another. E.g. a nuclear plant
+    might transform a uranium commodity into heat or electricity.
+    """
+
+    def __init__(self,
+                 tech_name,
+                 input_comm,
+                 output_comm,
+                 units,
+                 tech_label='p',
+                 description='',
+                 category=''):
+        """
+        This class contains information about a technology used
+        in a Temoa model.
+
+        Parameters
+        ----------
+        tech_name : string
+            The name of the technology
+        tech_label : string
+            The label of the technology. Describes how the technology
+            is used in Temoa. Currently accepts:
+            * 'r' (resource import)
+            * 'p' (production, general)
+            * 'ps' (production, storage)
+            * 'pb' (production, baseload)
+
+        """

--- a/pygenesys/technology/technology.py
+++ b/pygenesys/technology/technology.py
@@ -1,9 +1,11 @@
 
-#==============================================================================
-#==============================================================================
+# ==============================================================================
+# ==============================================================================
 # Defines Technology
-#==============================================================================
-#==============================================================================
+# ==============================================================================
+# ==============================================================================
+
+
 class Technology(object):
     """
     This class holds the information for technologies
@@ -81,13 +83,12 @@ class Technology(object):
         self.cost_fixed = cost_fixed
         self.cost_capital = cost_capital
 
-
         return
 
     def __repr__(self):
-        return  (f"{self._type}"+
-                f"(\"{self.tech_name}\","+
-                f"\"{self.tech_label}\","+
+        return (f"{self._type}" +
+                f"(\"{self.tech_name}\"," +
+                f"\"{self.tech_label}\"," +
                 f"\"{self.units}\")")
 
     def _db_entry(self):
@@ -97,10 +98,9 @@ class Technology(object):
                 self.description + ", " + self.units,
                 self.category)
 
-
-    def add_tech_region(self,
-                        region,
-                        **kwargs):
+    def add_tech_data(self,
+                      region,
+                      **kwargs):
         """
         This function adds regional data for each parameter.
         Non-required items are kwargs.
@@ -109,11 +109,10 @@ class Technology(object):
         """
         # check if region is a list or a string.
 
-
         # check if region already exists
         if region in self.regions:
-            print(f'Technology already exists in the {region} region.'+
-                   'Overwriting.')
+            print(f'Technology already exists in the {region} region.' +
+                  'Overwriting.')
         else:
             self.regions.append(region)
 

--- a/pygenesys/technology/technology.py
+++ b/pygenesys/technology/technology.py
@@ -17,6 +17,13 @@ class Technology(object):
                  input_comm,
                  output_comm,
                  units,
+                 regions=[],
+                 tech_lifetime=None,
+                 loan_lifetime=None,
+                 cost_variable=None,
+                 cost_fixed=None,
+                 cost_capital=None,
+                 tech_sector='energy',
                  tech_label='p',
                  description='',
                  category=''):
@@ -35,5 +42,97 @@ class Technology(object):
             * 'p' (production, general)
             * 'ps' (production, storage)
             * 'pb' (production, baseload)
+        tech_sector : string
+            The name of the technology sector. E.g. residential, electric,
+            industrial. This option is used to group technologies by sector
+            in post-processing steps.
+        input_comm : Commodity object
+            The commodity that a technology receives as input and
+            subsequently transforms.
+        output_comm : Commodity object
+            The commodity that a technology outputs after transforming
+            the input commodity.
+        units : string or pint Quantity object.
+            This specifies the units for the technology. Helps
+            calculate the ``cap2act`` property for the ``Capacity2Activity
+            table in Temoa.
+        tech_lifetime : integer
+            The operational lifetime of the technology.
+        loan_lifetime : integer
+            The ammortization period of the technology capital cost.
+        description : string
+             A short 1-4 word description of the technology.
+        category : string
+            The fuel category of the technology. Optional attribute.
+        """
+        self._type = 'Technology'
+        self.tech_name = tech_name
+        self.tech_sector = tech_sector
+        self.tech_label = tech_label
+        self.description = description
+        self.category = category
+        self.input_comm = input_comm
+        self.output_comm = output_comm
+        self.units = units
+        self.regions = regions
+        self.tech_lifetime = tech_lifetime
+        self.loan_lifetime = loan_lifetime
+        self.cost_variable = cost_variable
+        self.cost_fixed = cost_fixed
+        self.cost_capital = cost_capital
+
+
+        return
+
+    def __repr__(self):
+        return  (f"{self._type}"+
+                f"(\"{self.tech_name}\","+
+                f"\"{self.tech_label}\","+
+                f"\"{self.units}\")")
+
+    def _db_entry(self):
+        return (self.tech_name,
+                self.tech_label,
+                self.tech_sector,
+                self.description + ", " + self.units,
+                self.category)
+
+
+    def add_tech_region(self,
+                        region,
+                        **kwargs):
+        """
+        This function adds regional data for each parameter.
+        Non-required items are kwargs.
+
 
         """
+        # check if region is a list or a string.
+
+
+        # check if region already exists
+        if region in self.regions:
+            print(f'Technology already exists in the {region} region.'+
+                   'Overwriting.')
+        else:
+            self.regions.append(region)
+
+        return
+
+
+if __name__ == '__main__':
+    t = Technology(tech_name='kitchenaid',
+                   input_comm='flour',
+                   output_comm='dough',
+                   units='lbs',
+                   tech_sector='home')
+
+    print(t._db_entry())
+    print(repr(t))
+
+    if isinstance(t, Technology):
+        print('success')
+    else:
+        print('fail')
+
+    print(t._type)

--- a/pygenesys/tests/test_pygenesys.py
+++ b/pygenesys/tests/test_pygenesys.py
@@ -2,14 +2,6 @@ from pygenesys import technology
 from pygenesys import driver
 
 
-def test_technology_placeholder_is_none():
-    ret_value = technology.placeholder()
-
-    assert(ret_value is None)
-
-    return
-
-
 def test_name_from_path():
     assert(driver.name_from_path("/Users/test/test.py") == "test")
     assert(driver.name_from_path("/Users/test/test") == "test")

--- a/pygenesys/utils/db_creator.py
+++ b/pygenesys/utils/db_creator.py
@@ -427,19 +427,19 @@ def create_demand_specific_distribution(connector,
         The command for creating the SQLite table.
     """
     table_command = """CREATE TABLE "DemandSpecificDistribution" (
-    	"regions"	text,
-    	"season_name"	text,
-    	"time_of_day_name"	text,
-    	"demand_name"	text,
-    	"dds"	real CHECK("dds" >= 0 AND "dds" <= 1),
-    	"dds_notes"	text,
-    	PRIMARY KEY("regions","season_name","time_of_day_name","demand_name"),
-    	FOREIGN KEY("season_name") REFERENCES "time_season"("t_season"),
-    	FOREIGN KEY("time_of_day_name") REFERENCES "time_of_day"("t_day"),
-    	FOREIGN KEY("demand_name") REFERENCES "commodities"("comm_name")
-        );"""
+                	"regions"	text,
+                	"season_name"	text,
+                	"time_of_day_name"	text,
+                	"demand_name"	text,
+                	"dds"	real CHECK("dds" >= 0 AND "dds" <= 1),
+                	"dds_notes"	text,
+                	PRIMARY KEY("regions","season_name","time_of_day_name","demand_name"),
+                	FOREIGN KEY("season_name") REFERENCES "time_season"("t_season"),
+                	FOREIGN KEY("time_of_day_name") REFERENCES "time_of_day"("t_day"),
+                	FOREIGN KEY("demand_name") REFERENCES "commodities"("comm_name")
+                    );"""
     insert_command = """
-     INSERT INTO "DemandSpecificDistribution" VALUES (?,?,?,?,?,?)
+                     INSERT INTO "DemandSpecificDistribution" VALUES (?,?,?,?,?,?)
                      """
 
     cursor = connector.cursor()

--- a/pygenesys/utils/db_creator.py
+++ b/pygenesys/utils/db_creator.py
@@ -495,13 +495,13 @@ def create_technology_labels(connector):
               ("ps", "storage production technology"),
               ("r", "resource technology")]
 
-
     cursor = connector.cursor()
     cursor.execute(table_command)
     cursor.executemany(insert_command, labels)
     connector.commit()
 
     return
+
 
 def create_sectors(connector, sector_list):
 
@@ -524,6 +524,7 @@ def create_sectors(connector, sector_list):
 
     return
 
+
 def create_technologies(connector, technology_list):
     """
     Creates the ``technologies`` table in Temoa.
@@ -537,7 +538,7 @@ def create_technologies(connector, technology_list):
         All of the technologies initialized in the input file
     """
 
-    table_command= """
+    table_command = """
                     CREATE TABLE "technologies" (
                     "tech"	text,
                     "flag"	text,
@@ -559,6 +560,8 @@ def create_technologies(connector, technology_list):
     connector.commit()
 
     return table_command
+
+
 """
 
 

--- a/pygenesys/utils/db_creator.py
+++ b/pygenesys/utils/db_creator.py
@@ -361,7 +361,7 @@ def create_demand_table(connector, demand_list, years):
 
     years : list or array
         A list of the years in the model simulation.
-        
+
     Returns
     -------
     table_command : string
@@ -464,28 +464,101 @@ def create_demand_specific_distribution(connector,
     connector.commit()
     return table_command
 
+
+def create_technology_labels(connector):
+    """
+    Writes a ``technology_labels`` table to an SQLite database.
+
+    Parameters
+    ----------
+    connector : sqlite3 connection object
+        Used to connect to and write to an sqlite database.
+
+    Returns
+    -------
+    table_command : string
+        The command for generating the "commodity_labels" table.
+    """
+    table_command = """CREATE TABLE "technology_labels" (
+    	"tech_labels"	text,
+    	"tech_labels_desc"	text,
+    	PRIMARY KEY("tech_labels")
+    );
+                    """
+
+    insert_command = """
+                     INSERT INTO "technology_labels" VALUES (?,?)
+                     """
+    labels = [("p", "production technology"),
+              ("pb", "baseload production technology"),
+              ("ps", "storage production technology"),
+              ("r", "resource technology")]
+
+
+    cursor = connector.cursor()
+    cursor.execute(table_command)
+    cursor.executemany(insert_command, labels)
+    connector.commit()
+
+    return
+
+def create_sectors(connector, sector_list):
+
+    table_command = """
+                    CREATE TABLE "sector_labels" (
+                    "sector"	text,
+                    PRIMARY KEY("sector")
+                    );"""
+
+    insert_command = """
+                     INSERT INTO "sector_labels" VALUES (?)
+                     """
+
+    sectors = [[s] for s in sector_list]
+
+    cursor = connector.cursor()
+    cursor.execute(table_command)
+    cursor.executemany(insert_command, sectors)
+    connector.commit()
+
+    return
+
+def create_technologies(connector, technology_list):
+    """
+    Creates the ``technologies`` table in Temoa.
+
+    Parameters
+    ----------
+    connector : sqlite connector
+        The connection to an sqlite database
+
+    technology_list : list of ``Technology`` objects
+        All of the technologies initialized in the input file
+    """
+
+    table_command= """
+                    CREATE TABLE "technologies" (
+                    "tech"	text,
+                    "flag"	text,
+                    "sector"	text,
+                    "tech_desc"	text,
+                    "tech_category"	text,
+                    PRIMARY KEY("tech"),
+                    FOREIGN KEY("flag") REFERENCES "technology_labels"("tech_labels"),
+                    FOREIGN KEY("sector") REFERENCES "sector_labels"("sector")
+                    );"""
+    insert_command = """
+                     INSERT INTO "technologies" VALUES (?,?,?,?,?)
+                     """
+    tech_entries = [tech._db_entry() for tech in technology_list]
+
+    cursor = connector.cursor()
+    cursor.execute(table_command)
+    cursor.executemany(insert_command, tech_entries)
+    connector.commit()
+
+    return table_command
 """
-def create_():
-CREATE TABLE "technology_labels" (
-	"tech_labels"	text,
-	"tech_labels_desc"	text,
-	PRIMARY KEY("tech_labels")
-);
-return
-
-
-def create_():
-CREATE TABLE "technologies" (
-	"tech"	text,
-	"flag"	text,
-	"sector"	text,
-	"tech_desc"	text,
-	"tech_category"	text,
-	PRIMARY KEY("tech"),
-	FOREIGN KEY("flag") REFERENCES "technology_labels"("tech_labels"),
-	FOREIGN KEY("sector") REFERENCES "sector_labels"("sector")
-);
-return
 
 
 def create_():
@@ -536,12 +609,6 @@ CREATE TABLE "tech_annual" (
 );
 return
 
-def create_():
-CREATE TABLE "sector_labels" (
-	"sector"	text,
-	PRIMARY KEY("sector")
-);
-return
 
 
 def create_():

--- a/pygenesys/utils/db_creator.py
+++ b/pygenesys/utils/db_creator.py
@@ -427,19 +427,19 @@ def create_demand_specific_distribution(connector,
         The command for creating the SQLite table.
     """
     table_command = """CREATE TABLE "DemandSpecificDistribution" (
-                    	"regions"	text,
-                    	"season_name"	text,
-                    	"time_of_day_name"	text,
-                    	"demand_name"	text,
-                    	"dds"	real CHECK("dds" >= 0 AND "dds" <= 1),
-                    	"dds_notes"	text,
-                    	PRIMARY KEY("regions","season_name","time_of_day_name","demand_name"),
-                    	FOREIGN KEY("season_name") REFERENCES "time_season"("t_season"),
-                    	FOREIGN KEY("time_of_day_name") REFERENCES "time_of_day"("t_day"),
-                    	FOREIGN KEY("demand_name") REFERENCES "commodities"("comm_name")
-                    );"""
+    	"regions"	text,
+    	"season_name"	text,
+    	"time_of_day_name"	text,
+    	"demand_name"	text,
+    	"dds"	real CHECK("dds" >= 0 AND "dds" <= 1),
+    	"dds_notes"	text,
+    	PRIMARY KEY("regions","season_name","time_of_day_name","demand_name"),
+    	FOREIGN KEY("season_name") REFERENCES "time_season"("t_season"),
+    	FOREIGN KEY("time_of_day_name") REFERENCES "time_of_day"("t_day"),
+    	FOREIGN KEY("demand_name") REFERENCES "commodities"("comm_name")
+        );"""
     insert_command = """
-                     INSERT INTO "DemandSpecificDistribution" VALUES (?,?,?,?,?,?)
+     INSERT INTO "DemandSpecificDistribution" VALUES (?,?,?,?,?,?)
                      """
 
     cursor = connector.cursor()


### PR DESCRIPTION
This PR adds the following tables to ``db_creator.py``. This PR closes #2. 

* ``create_sectors``
* ``create_technology_labels``
* ``create_technologies``

This PR may appear large, however the important differences are in ``db_creator.py``, ``driver.py``, and ``model_info.py``. 

In ``driver.py`` I added a function ``_collect_technologies`` which gathers all of the initialized technologies in the pygenesys input file. The motivation for this is to avoid having users declare a technology and then asking them to add it to a list in the input file. I.e. the workflow considered previously was:
1. Declare a technology
```py
my_tech = Technology(...)
# or 
from pygenesys.technology.supply import my_tech
```
2. Add that technology to a list or dictionary of all technologies
```py
technologies = [my_tech]
```
3. ``driver.py`` passes ``infile.technologies`` to a ``ModelInfo`` instance.  

The new workflow is
1. Declare the technology as before
2. ``driver.py`` collects the ``Technology`` objects from the input file and passes the list to a ``ModelInfo`` instance.

This is desired because it reduces the number of required steps for users. 


**NOTE** 
In next PR, region dependent parameters and tables will be added. Users will be required to specify the parameters for each region (e.g. efficiency). The method ``add_tech_data`` will be completed next. It was introduced but left incomplete in this PR to keep it small. An associated issue will be created.