### PR TITLE
fixes duplicate create tech_input_split

### DIFF
--- a/pygenesys/model_info.py
+++ b/pygenesys/model_info.py
@@ -188,6 +188,7 @@ class ModelInfo(object):
         create_max_capacity(conn, self.technologies)
         create_min_capacity(conn, self.technologies)
         create_existing_capacity(conn, self.technologies, self.time_horizon)
+        create_tech_input_split(conn)
         create_efficiency(conn, self.technologies, self.time_horizon)
         create_emissions_activity(conn, self.technologies, self.time_horizon)
         create_invest_cost(conn, self.technologies, self.time_horizon)

--- a/pygenesys/utils/db_creator.py
+++ b/pygenesys/utils/db_creator.py
@@ -639,7 +639,7 @@ def create_efficiency(connector, technology_list, future):
                 assert N_inputs == len(tech.efficiency[place]), "Mismatched number of inputs and efficiencies"
                 # pass to tech_input_split
                 eff_list = tech.efficiency[place]
-                create_tech_input_split(connector,
+                add_tech_input_split(connector,
                                         place,
                                         tech,
                                         future,
@@ -1780,7 +1780,7 @@ def create_MyopicBaseYear(connector):
     return
 
 
-def create_tech_input_split(connector, region, tech, time_periods, comm_list, eff_list):
+def create_tech_input_split(connector):
     """
     Creates the tech input split table
     """
@@ -1801,6 +1801,16 @@ def create_tech_input_split(connector, region, tech, time_periods, comm_list, ef
 
     cursor = connector.cursor()
     cursor.execute(table_command)
+
+    connector.commit()
+    return
+
+
+def add_tech_input_split(connector, region, tech, time_periods, comm_list, eff_list):
+    """
+    Adds data to the tech input split table
+    """
+    cursor = connector.cursor()
 
     # I think this is the correct way to do an input split... not sure how
     # else to break it down.
@@ -1824,7 +1834,6 @@ def create_tech_input_split(connector, region, tech, time_periods, comm_list, ef
 
     connector.commit()
     return
-
 """
 
 


### PR DESCRIPTION
This PR addresses #36 which produced an error trying to create two technologies that use tech input split.